### PR TITLE
fix: make sure we only error when status is neither 200 nor 201

### DIFF
--- a/logsnag.go
+++ b/logsnag.go
@@ -57,7 +57,7 @@ func (logsnag *LogSnag) Publish(input *PublishRequest) error {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK || res.StatusCode != http.StatusCreated {
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		b, _ := io.ReadAll(res.Body)
 		fmt.Println("body response error: ", string(b))
 		return fmt.Errorf("logsnag: LogSnag.Publish unexpected http response status <%d> error", res.StatusCode)


### PR DESCRIPTION
Errors were always being logged due to a typo in the condition that checks for successful requests. This PR fixes the typo.